### PR TITLE
Updating the examples link

### DIFF
--- a/extras/docs/quickstart.rst
+++ b/extras/docs/quickstart.rst
@@ -123,4 +123,4 @@ Going further
 The examples_ directory of the library contains several example sketches
 that demonstrate the different functionality of the library.
 
-.. _examples: https://bitbucket.org/pjhardy/kerbalsimpit-arduino/src/main/examples/
+.. _examples: https://github.com/Simpit-team/KerbalSimpitRevamped-Arduino/tree/main/examples

--- a/extras/docs/quickstart.rst
+++ b/extras/docs/quickstart.rst
@@ -123,4 +123,4 @@ Going further
 The examples_ directory of the library contains several example sketches
 that demonstrate the different functionality of the library.
 
-.. _examples: https://bitbucket.org/pjhardy/kerbalsimpit-arduino/src/master/examples/
+.. _examples: https://bitbucket.org/pjhardy/kerbalsimpit-arduino/src/main/examples/


### PR DESCRIPTION
Changed the link for the examples page from kerbalsimpit-arduino/src/master/examples/ to kerbalsimpit-arduino/src/main/examples/